### PR TITLE
Fix bug of converter to yolo format

### DIFF
--- a/labelu/internal/common/converter.py
+++ b/labelu/internal/common/converter.py
@@ -600,7 +600,7 @@ class Converter:
                             height /= image_height
                             
                             outfile.write(f"{classes.index(label)} {x_center} {y_center} {width} {height}\n")
-                            export_files.append(file_name)
+            export_files.append(file_name)
             
             
         file_relative_path_zip = f"task-{out_data_file_name_prefix}-yolo.zip"


### PR DESCRIPTION
Fixed an issue where multiple redundant files with the same name were generated when exporting YOLO format annotation files **due to accidental indentation**.

The example of this issue is as follows:
![image](https://github.com/user-attachments/assets/ee3ada1c-e994-400e-808b-071b350b1c4f)
