### PR TITLE
fix: use shutil.move to handle cross-device file upload

### DIFF
--- a/labelu/internal/common/storage.py
+++ b/labelu/internal/common/storage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import lru_cache
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -60,7 +61,7 @@ class LocalStorageBackend(StorageBackend):
     def save_file(self, local_path: Path, key: str, content_type: Optional[str] = None) -> None:
         target_path = self._resolve(key)
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        local_path.replace(target_path)
+        shutil.move(str(local_path), str(target_path))
 
     def save_bytes(self, content: bytes, key: str, content_type: Optional[str] = None) -> None:
         target_path = self._resolve(key)


### PR DESCRIPTION
Base repository：opendatalab/labelU，base：main
## Problem
When running LabelU in Docker with `/tmp` and the media directory 
mounted on different devices, uploading files fails with:

[Errno 18] Invalid cross-device link: '/tmp/tmpxxx' -> '/root/.local/share/labelu/media/upload/...'

## Root Cause
`LocalStorage.save_file` uses `Path.replace()` which calls `os.rename()` 
under the hood. `os.rename()` cannot move files across different mount 
points or devices.

## Fix
Replace `local_path.replace(target_path)` with 
`shutil.move(str(local_path), str(target_path))`.

`shutil.move()` gracefully falls back to copy+delete when moving 
across devices, resolving the issue.

## File Changed
`labelu/internal/common/storage.py`