### PR TITLE
fix: 修复transformers 新版本（box_threshold 合并为 threshold）

### DIFF
--- a/model_server/grounding_dino_sam/server.py
+++ b/model_server/grounding_dino_sam/server.py
@@ -110,7 +110,7 @@ def _detect_objects(
     post = dino_processor.post_process_grounded_object_detection(
         outputs,
         inputs.input_ids,
-        box_threshold=box_threshold,
+        threshold=box_threshold,
         text_threshold=text_threshold,
         target_sizes=[image.size[::-1]],
     )[0]


### PR DESCRIPTION
## 问题描述

在 `transformers>=4.39.0`（ v5.12.0）中，`GroundingDINOProcessor.post_process_grounded_object_detection()` 方法的参数发生了变化：

- **旧版本**（<=4.38.2）：使用 `box_threshold` 和 `text_threshold` 两个独立参数
- **新版本**（>=4.39.0）：合并为单一的 `threshold` 参数

当前代码使用的是旧版参数，导致在新版本环境下运行时报错：
TypeError: post_process_grounded_object_detection() got an unexpected keyword argument 'box_threshold'